### PR TITLE
Add import conflict preview and update handling

### DIFF
--- a/packages/server/src/controllers/export-import/index.ts
+++ b/packages/server/src/controllers/export-import/index.ts
@@ -45,7 +45,33 @@ const importData = async (req: Request, res: Response, next: NextFunction) => {
     }
 }
 
+const previewImportData = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const workspaceId = req.user?.activeWorkspaceId
+        if (!workspaceId) {
+            throw new InternalFlowiseError(
+                StatusCodes.NOT_FOUND,
+                `Error: exportImportController.previewImportData - workspace ${workspaceId} not found!`
+            )
+        }
+
+        const importData = req.body
+        if (!importData) {
+            throw new InternalFlowiseError(
+                StatusCodes.BAD_REQUEST,
+                'Error: exportImportController.previewImportData - importData is required!'
+            )
+        }
+
+        const preview = await exportImportService.previewImportData(importData, workspaceId)
+        return res.status(StatusCodes.OK).json(preview)
+    } catch (error) {
+        next(error)
+    }
+}
+
 export default {
     exportData,
-    importData
+    importData,
+    previewImportData
 }

--- a/packages/server/src/routes/export-import/index.ts
+++ b/packages/server/src/routes/export-import/index.ts
@@ -5,6 +5,8 @@ const router = express.Router()
 
 router.post('/export', checkPermission('workspace:export'), exportImportController.exportData)
 
+router.post('/preview', checkPermission('workspace:import'), exportImportController.previewImportData)
+
 router.post('/import', checkPermission('workspace:import'), exportImportController.importData)
 
 export default router

--- a/packages/ui/src/api/exportimport.js
+++ b/packages/ui/src/api/exportimport.js
@@ -2,8 +2,10 @@ import client from './client'
 
 const exportData = (body) => client.post('/export-import/export', body)
 const importData = (body) => client.post('/export-import/import', body)
+const previewImportData = (body) => client.post('/export-import/preview', body)
 
 export default {
     exportData,
-    importData
+    importData,
+    previewImportData
 }


### PR DESCRIPTION
## Summary
- add a preview endpoint to surface name conflicts during import and allow conflict resolution metadata to be sent to the importer
- update the import service to honor per-entity update selections, remap identifiers, and avoid duplicate quotas when updating
- extend the UI import flow with a review dialog, conflict toggles, and preview API integration before executing the import

## Testing
- `pnpm run lint packages/server/src/services/export-import/index.ts packages/server/src/controllers/export-import/index.ts packages/server/src/routes/export-import/index.ts packages/ui/src/api/exportimport.js packages/ui/src/layout/MainLayout/Header/ProfileSection/index.jsx` *(fails: ESLint v9 expects eslint.config.js in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ed58cfe5d4832992c5e2b3013c3910