### PR TITLE
Fix export-import assistant type mapping duplication

### DIFF
--- a/packages/server/src/services/export-import/index.ts
+++ b/packages/server/src/services/export-import/index.ts
@@ -109,7 +109,6 @@ const chatflowTypeByKey: Partial<Record<ConflictEntityKey, EnumChatflowType>> = 
 }
 
 const assistantTypeByKey: Partial<Record<ConflictEntityKey, AssistantType>> = {
-const assistantTypeByKey: Partial<Record<ConflictEntityKey, string>> = {
     AssistantCustom: 'CUSTOM',
     AssistantOpenAI: 'OPENAI',
     AssistantAzure: 'AZURE'


### PR DESCRIPTION
## Summary
- remove the duplicate assistant type mapping declaration that was breaking TypeScript compilation in the export/import service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ed750ed1148329b3f3ada0a549bd45