### PR TITLE
Fix duplicate document store sections when switching tabs

### DIFF
--- a/packages/ui/src/layout/MainLayout/Header/ProfileSection/index.jsx
+++ b/packages/ui/src/layout/MainLayout/Header/ProfileSection/index.jsx
@@ -390,7 +390,7 @@ const ImportReviewDialog = ({
 
                                             return (
                                                 <Box
-                                                    key={type}
+                                                    key={`conflict-${type}`}
                                                     sx={{
                                                         border: '1px solid',
                                                         borderColor,
@@ -568,7 +568,7 @@ const ImportReviewDialog = ({
 
                                         return (
                                             <Box
-                                                key={type}
+                                                key={`new-${type}`}
                                                 sx={{
                                                     border: '1px solid',
                                                     borderColor,


### PR DESCRIPTION
## Summary
- ensure conflict and new item sections in the import review dialog have distinct React keys so their content does not mix when switching tabs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f0040e3ba083298dc816ddeb431f4b