### PR TITLE
Fix conflict selection keys and accordion support in import review

### DIFF
--- a/packages/ui/src/layout/MainLayout/Header/ProfileSection/index.jsx
+++ b/packages/ui/src/layout/MainLayout/Header/ProfileSection/index.jsx
@@ -90,13 +90,19 @@ const importTypeLabels = {
     AssistantOpenAI: 'OpenAI Assistant',
     AssistantAzure: 'Azure Assistant',
     ChatFlow: 'Chat Flow',
+    ChatMessage: 'Chat Message',
     CustomTemplate: 'Custom Template',
     DocumentStore: 'Document Store',
+    DocumentStoreFileChunk: 'Document Store File Chunk',
+    Execution: 'Execution',
     Tool: 'Tool',
     Variable: 'Variable'
 }
 
-const getConflictKey = (conflict) => `${conflict.type}:${conflict.importId}`
+const getConflictKey = (conflict = {}) => {
+    const { type, existingId, importId, id, name } = conflict
+    return [type, existingId, importId ?? id ?? name].filter(Boolean).join(':')
+}
 
 const getImportItemName = (type, item) => {
     if (!item) return ''
@@ -261,8 +267,11 @@ const ImportReviewDialog = ({
                 'AssistantOpenAI',
                 'AssistantAzure',
                 'ChatFlow',
+                'ChatMessage',
                 'CustomTemplate',
                 'DocumentStore',
+                'DocumentStoreFileChunk',
+                'Execution',
                 'Tool',
                 'Variable'
             ]),
@@ -303,8 +312,14 @@ const ImportReviewDialog = ({
             AssistantOpenAI: { label: importTypeLabels.AssistantOpenAI, color: theme.palette.primary.main },
             AssistantAzure: { label: importTypeLabels.AssistantAzure, color: theme.palette.secondary.main },
             ChatFlow: { label: importTypeLabels.ChatFlow, color: theme.palette.primary.dark },
+            ChatMessage: { label: importTypeLabels.ChatMessage, color: theme.palette.primary.light },
             CustomTemplate: { label: importTypeLabels.CustomTemplate, color: theme.palette.error.main },
             DocumentStore: { label: importTypeLabels.DocumentStore, color: theme.palette.secondary.dark },
+            DocumentStoreFileChunk: {
+                label: importTypeLabels.DocumentStoreFileChunk,
+                color: theme.palette.secondary.light
+            },
+            Execution: { label: importTypeLabels.Execution, color: theme.palette.info.light },
             Tool: { label: importTypeLabels.Tool, color: theme.palette.success.dark },
             Variable: { label: importTypeLabels.Variable, color: theme.palette.warning.dark }
         }),


### PR DESCRIPTION
## Summary
- ensure conflict selections and actions use unique keys so similarly named conflicts stay independent
- add labels, colors, and accordion eligibility for chat messages, document store file chunks, and executions in the new items list

## Testing
- Not run (UI lint command unavailable in workspace)


------
https://chatgpt.com/codex/tasks/task_b_68f0d4c17f9c83299704c2128c4e2f71